### PR TITLE
검색 기능이 동작하도록 수정

### DIFF
--- a/_plugins/simple_search_filter.rb
+++ b/_plugins/simple_search_filter.rb
@@ -5,6 +5,10 @@ module Jekyll
       input.gsub! /\t/, '    '
       input.strip_control_and_extended_characters
     end
+    def mathmode(input)
+      input.gsub! '\\',''
+      input.gsub '$',''
+    end
   end
 end
 

--- a/_plugins/simple_search_filter.rb
+++ b/_plugins/simple_search_filter.rb
@@ -7,7 +7,8 @@ module Jekyll
     end
     def mathmode(input)
       input.gsub! '\\',''
-      input.gsub '$',''
+      input.gsub! '$',''
+      input.gsub /[\u0000-\u001f\u007f]/,''
     end
   end
 end

--- a/_posts/2021-09-19-planar-mincut.md
+++ b/_posts/2021-09-19-planar-mincut.md
@@ -3,7 +3,7 @@ layout: post
 title: Minimum $s - t$ cut of a planar undirected graph in $O(n \log^2 n)$ time
 date: 2021-09-19 22:00
 author: koosaga
-tags: algorithms, graph theory, divide and conquer
+tags: algorithms graph-theory divide-and-conquer
 ---
 # Minimum $s - t$ cut of a planar undirected graph in $O(n \log^2 n)$ time
 

--- a/_tags/divide-and-conquer.md
+++ b/_tags/divide-and-conquer.md
@@ -1,0 +1,4 @@
+---
+name: divide-and-conquer
+title: 'divide-and-conquer'
+---

--- a/search2.json
+++ b/search2.json
@@ -4,25 +4,12 @@ layout: null
 [
   {% for post in site.posts %}
     {
-      "title"    : "{{ post.title | escape }}",
+      "title"    : "{{ post.title | mathmode | escape }}",
       "category" : "{{ post.category }}",
       "tags"     : "{{ post.tags | array_to_sentence_string }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "date"     : "{{ post.date }}",
       "content"   : {{ post.content | jsonify }}
     } {% unless forloop.last %},{% endunless %}
-  {% endfor %}
-  {% for page in site.pages %}
-    {% if page.title != nil and page.title != 'Tags' %}
-,
-  {
-    "title"    : "{{ page.title | escape }}",
-    "category" : "{{ page.category }}",
-    "tags"     : "{{ page.tags | join: ', ' }}",
-    "url"      : "{{ site.baseurl }}{{ page.url }}",
-    "date"     : "{{ page.date }}",
-    "content"   : {{ page.content | jsonify }}
-  }
-    {% endif %}
   {% endfor %}
 ]


### PR DESCRIPTION
글을 쓰려다 보니 검색 기능이 아예 동작하지 않는 버그가 있어서 이를 수정합니다.

- 이번에 문제가 되었던 글은 [이 글](http://www.secmem.org/blog/2021/09/19/planar-mincut/)입니다. 이 글의 태그가 동작하도록 수정합니다.
  - `algorithms`와 `graph-theory`는 해당 태그명에 병합하고, `divide-and-conquer`는 새 태그를 만듭니다.
- 글의 제목에 `$`와 `\`가 포함되어 있는 경우 검색 문자열에서 제거하도록 수정합니다.
  - 적지 않은 글이 검색에 영향을 받습니다만, 대부분 더 좋은 방향으로 영향을 받습니다. (검색에 제목이 일치할 시 굳이 수식 기호를 적지 않아도 계속 검색됩니다. `$`가 들어간 문자열은 애초에 검색조차 되지 않습니다.)
- 더 이상 pagination 부분이 검색에 적용되지 않도록 수정합니다.
  - 기존에 검색 기능이 작동하는 상태에서, `S/W`를 검색하면 **S/W 멤버십 기술 블로그**라는 페이지 글이 수십 개씩 검색 결과로 노출되었습니다.
  - 이 블로그는 pagination을 별도의 글로 사용하지 않기 때문에 검색 대상에서 제외합니다.

글을 작성할 때 수식은 꼭 필요한 경우가 아니면 제목으로 쓰는 것을 삼가 주시고, 그래야만 한다면 꼭 컴파일해서 **제목이 제대로 보이는지**, **검색 기능이 동작하는지** 확인해 봅시다.

closes #474.