### PR TITLE
Fix search2.json

### DIFF
--- a/search2.json
+++ b/search2.json
@@ -4,7 +4,7 @@ layout: null
 [
   {% for post in site.posts %}
     {
-      "title"    : "{{ post.title | mathmode | escape }}",
+      "title"    : {{ post.title | mathmode | jsonify }},
       "category" : "{{ post.category }}",
       "tags"     : "{{ post.tags | array_to_sentence_string }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",


### PR DESCRIPTION
제목을 proper하게 escape하지 못하는 문제를 해결했습니다.

@kipa00 `mathmode`가 필요한 이유를 알 수 있을까요?